### PR TITLE
Enable JSON indexed extractions

### DIFF
--- a/app/default/props.conf
+++ b/app/default/props.conf
@@ -1,6 +1,15 @@
+#
+# Splunk props configuration file
+#
+# See https://docs.splunk.com/Documentation/Splunk/9.0.0/Admin/Propsconf for the file specification.
+#
+
 [tyk:pump]
 category = Structured
 description = Events produced by Tyk Pump.
+
+INDEXED_EXTRACTIONS = JSON
+KV_MODE = none
 
 # Remove Splunk wildcard characters from the api_key field
 SEDCMD-remove_wildcard_chars = s/"api_key":"\*{4}(\w+)"/"api_key":"\1"/g


### PR DESCRIPTION
This will allow us to use `tstats` on fields such as `alias` to better report on Tyk usage.

e.g. we can't currently do:

```
| tstats prestats=t count WHERE index="tyk" alias="<api-client-id>"
| stats count
```